### PR TITLE
Fix: Use persistent secret key for session management

### DIFF
--- a/ragam_textiles/app.py
+++ b/ragam_textiles/app.py
@@ -3,7 +3,8 @@ from flask_sqlalchemy import SQLAlchemy
 import os
 
 app = Flask(__name__)
-app.secret_key = os.urandom(24)  # For session management
+# Use a fixed secret key for session management
+app.secret_key = "your_super_secret_and_random_key_here"  # CHANGE THIS IN PRODUCTION!
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///ragam_textiles.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False # silence the warning
 db = SQLAlchemy(app)


### PR DESCRIPTION
Replaced the dynamic generation of Flask's secret key with a fixed string. This prevents sessions from being invalidated on application restart, which was likely causing the admin user to be logged out immediately after login.