### PR TITLE
Fix: Correct IndentationError by moving app.run into main block

### DIFF
--- a/ragam_textiles/app.py
+++ b/ragam_textiles/app.py
@@ -225,6 +225,7 @@ if __name__ == '__main__':
     # def init_db_command():
     #     init_db()
     #     click.echo("Initialized the database.")
+    app.run(debug=True)
 
 # Carousel Admin Routes
 UPLOAD_FOLDER_CAROUSEL = 'ragam_textiles/static/uploads/carousel_images'
@@ -339,5 +340,3 @@ def admin_delete_carousel_slide(slide_id):
     db.session.commit()
     flash('Carousel slide deleted successfully!', 'success')
     return redirect(url_for('admin_carousel'))
-
-    app.run(debug=True)


### PR DESCRIPTION
The IndentationError occurred because the `if __name__ == '__main__':` block lacked an indented statement. This commit moves `app.run(debug=True)` into this block, allowing the Flask development server to start correctly when the script is executed directly.